### PR TITLE
fix: show error message on invalid login credentials

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -26,7 +26,7 @@
       <p class="card-sub">Log in to your journal</p>
       {% with messages = get_flashed_messages() %}
         {% if messages %}
-          <div class="error-msg">{{ messages[0] }}</div>
+          <div class="error-msg show">{{ messages[0] }}</div>
         {% endif %}
       {% endwith %}
       <form method="POST" action="">


### PR DESCRIPTION
- Error message div had display:none by default
- Added 'show' class to make it visible when Flask flashes an error
- Fixes login error not showing on wrong email/password